### PR TITLE
Replace removed top4kyear with top4kmonth

### DIFF
--- a/tests/datasets.py
+++ b/tests/datasets.py
@@ -578,7 +578,7 @@ def get_opensuse_packages(project):
     return names
 
 
-def _intersect_stdlib(kind="top4kyear"):
+def _intersect_stdlib(kind="top4kmonth"):
     for name in get_top_packages(kind):
         if name not in _stdlib_all:
             continue

--- a/tests/test_top.py
+++ b/tests/test_top.py
@@ -19,7 +19,7 @@ failures = []
 repeat_expected = False
 
 
-def _fetch_names(kind="top4kyear", xstatic=False, ignore_failures=True):
+def _fetch_names(kind="top4kmonth", xstatic=False, ignore_failures=True):
     for name in get_top_packages(kind):
         if name in _stdlib:
             continue
@@ -94,9 +94,7 @@ class TestTop360(_TestBase):
 @expand
 class TestTopXStatic(_TestBase):
 
-    names = set(_fetch_names(xstatic=True, kind="top4kyear")) | set(
-        _fetch_names(xstatic=True, kind="top4kmonth")
-    )
+    names = list(_fetch_names(xstatic=True, kind="top4kmonth"))
 
     @foreach(names)
     def test_package(self, name):


### PR DESCRIPTION
Unfortunately I had to remove the list of top packages over the last _365 days_ from https://github.com/hugovk/top-pypi-packages because it was using too much quota.

See https://github.com/hugovk/top-pypi-packages/pull/21, https://github.com/hugovk/top-pypi-packages/pull/20, https://github.com/hugovk/top-pypi-packages/issues/19.

Therefore we need to use `top4kmonth` instead of `top4kyear` with inputset-generator.

---

However on the bright side, it meant I could bump the 30-day list from the top 4,000 back to the top 5,000 packages. I've created a PR at inputset-generator to remove the `top4kyear` option: https://github.com/returntocorp/inputset-generator/pull/35.

That PR also renames `top4kmonth` to `top5kmonth`, so we'll need another update when that is released.
