### PR TITLE
Replace deprecated brotlipy with brotlicffi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     install_requires=[
         "https-everywhere",
         "requests[security]",
-        "brotlipy",  # urllib3 optional dep
+        "brotlicffi",  # urllib3 optional dep
         "CacheControl",
         "cachetools",
         "lockfile",


### PR DESCRIPTION
I've not tested this PR, but brotlipy was renamed to brotlicffi in 2020 and brotlipy is deprecated:

https://github.com/python-hyper/brotlicffi/blob/8e27c661a3e18cbc46e1058ecf74fb98aa2e6615/HISTORY.rst#080-2020-11-30

I'm seeing failures to build brotlipy on macOS for 3.9-3.11:

https://github.com/hugovk/pypi-tools/actions/runs/9743600600/job/26887402119?pr=55

```pytb
  Building wheel for brotlipy (setup.py): started
  Building wheel for brotlipy (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [28 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/sx/mf6nj_sn1ll2crpml02qjgbr0000gn/T/pip-install-_009hgvw/brotlipy_3c4e68b6e34c4f0a970263600354a59b/setup.py", line 9, in <module>
          setup(
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/__init__.py", line 152, in setup
          _install_setup_requires(attrs)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/__init__.py", line 147, in _install_setup_requires
          dist.fetch_build_eggs(dist.setup_requires)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/dist.py", line 806, in fetch_build_eggs
          resolved_dists = pkg_resources.working_set.resolve(
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pkg_resources/__init__.py", line 766, in resolve
          dist = best[req.key] = env.best_match(
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pkg_resources/__init__.py", line 1051, in best_match
          return self.obtain(req, installer)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pkg_resources/__init__.py", line 1063, in obtain
          return installer(requirement)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/dist.py", line 877, in fetch_build_egg
          return fetch_build_egg(self, req)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/installer.py", line 80, in fetch_build_egg
          wheel.install_as_egg(dist_location)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/wheel.py", line 95, in install_as_egg
          self._install_as_egg(destination_eggdir, zf)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/wheel.py", line 103, in _install_as_egg
          self._convert_metadata(zf, destination_eggdir, dist_info, egg_info)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/wheel.py", line 124, in _convert_metadata
          os.mkdir(destination_eggdir)
      FileExistsError: [Errno 17] File exists: '/private/var/folders/sx/mf6nj_sn1ll2crpml02qjgbr0000gn/T/pip-install-_009hgvw/brotlipy_3c4e68b6e34c4f0a970263600354a59b/.eggs/cffi-1.16.0-py3.9-macosx-10.9-universal2.egg'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for brotlipy
  Running setup.py clean for brotlipy
  error: subprocess-exited-with-error
  
  × python setup.py clean did not run successfully.
  │ exit code: 1
  ╰─> [28 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/sx/mf6nj_sn1ll2crpml02qjgbr0000gn/T/pip-install-_009hgvw/brotlipy_3c4e68b6e34c4f0a970263600354a59b/setup.py", line 9, in <module>
          setup(
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/__init__.py", line 152, in setup
          _install_setup_requires(attrs)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/__init__.py", line 147, in _install_setup_requires
          dist.fetch_build_eggs(dist.setup_requires)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/dist.py", line 806, in fetch_build_eggs
          resolved_dists = pkg_resources.working_set.resolve(
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pkg_resources/__init__.py", line 766, in resolve
          dist = best[req.key] = env.best_match(
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pkg_resources/__init__.py", line 1051, in best_match
          return self.obtain(req, installer)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pkg_resources/__init__.py", line 1063, in obtain
          return installer(requirement)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/dist.py", line 877, in fetch_build_egg
          return fetch_build_egg(self, req)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/installer.py", line 80, in fetch_build_egg
          wheel.install_as_egg(dist_location)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/wheel.py", line 95, in install_as_egg
          self._install_as_egg(destination_eggdir, zf)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/wheel.py", line 103, in _install_as_egg
          self._convert_metadata(zf, destination_eggdir, dist_info, egg_info)
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/wheel.py", line 124, in _convert_metadata
          os.mkdir(destination_eggdir)
      FileExistsError: [Errno 17] File exists: '/private/var/folders/sx/mf6nj_sn1ll2crpml02qjgbr0000gn/T/pip-install-_009hgvw/brotlipy_3c4e68b6e34c4f0a970263600354a59b/.eggs/cffi-1.16.0-py3.9-macosx-10.9-universal2.egg'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed cleaning build dir for brotlipy
```